### PR TITLE
Change domain from script to automation

### DIFF
--- a/notifications.yaml
+++ b/notifications.yaml
@@ -52,7 +52,7 @@ blueprint:
 
     ### Version 1.1 - *25 March 2023* [🔗](https://community.home-assistant.io/t/notification-with-confirm-dismiss-and-timeout/551552#version-11-25-march-2023-11)
 
-  domain: script
+  domain: automation
   source_url: https://github.com/samuelthng/t-house-blueprints/blob/main/notifications.yaml
   input:
     notify_device:


### PR DESCRIPTION
When integrating this into HA manually, by copying it under the `blueprints` directory, HA displays an error because it's an automation blueprint labeled as a script blueprint.