### PR TITLE
Added: override ability for `notification_link`

### DIFF
--- a/notifications.yaml
+++ b/notifications.yaml
@@ -877,6 +877,14 @@ fields:
     selector:
       boolean:
 
+  field_notification_link:
+    name: "🔗 Notification Link"
+    description: "Override notification link"
+    example: !input notification_link
+    default: !input notification_link
+    selector:
+      text:
+
   # [Unsupported due to `choose.sequence`] - Can't pass variables to choose.sequence.
   # field_timeout_action:
   #   name: "⌛️ Timeout Action(s)"
@@ -901,7 +909,8 @@ sequence:
       script_subtitle: !input subtitle
       subtitle: "{{ iif(field_subtitle is defined, field_subtitle, script_subtitle) }}"
       interruption_level: !input interruption_level
-      notification_link: !input notification_link
+      script_notification_link: !input notification_link
+      notification_link: "{{ iif(field_notification_link is defined, field_notification_link, script_notification_link) }}"
       visibility: !input visibility
       importance: !input importance
       custom_tag: !input tag # No need for manual definition anymore, treat existing definitions as custom tags.


### PR DESCRIPTION
Added one field to override, probably some other fields could be added as well, but I haven't tested. The Links overriding seems working fine.
I don't know the approach to manage the changelog, so kept as is.